### PR TITLE
conteudo: altera hierarquia de item devolutiva na consulta do arco tietê

### DIFF
--- a/src/views/MinutaSetorCentral.vue
+++ b/src/views/MinutaSetorCentral.vue
@@ -1589,7 +1589,9 @@
 					</a>
 				</li>
 			</ul>
-			<h3>Devolutivas</h3>
+		</section>
+		<section>
+			<h2 class="titulo" indent="1">Devolutivas</h2>
 			<ul class="links">
 				<li>
 					<a :href="src('arquivos/minuta-piu-setor-central/devolutivas/Devolutiva_Consulta_Publica.pdf')">


### PR DESCRIPTION
@lordscorp, atendendo a pedidos da equipe. uma pequena correção para incluir o item "devolutiva no menu lateral". **Não há alteração de conteúdo**

![Screenshot_2019-12-23 Participe Gestão Urbana](https://user-images.githubusercontent.com/4117768/71365862-0600a000-257f-11ea-8c56-7d5bbb290275.png)
