### PR TITLE
Adicionado Jest e primeiro teste funcionando como POC

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-	root: false,
+  root: false,
 	env: {
 		node: true
 	},
@@ -19,5 +19,16 @@ module.exports = {
 	},
 	parserOptions: {
 		parser: 'babel-eslint'
-	}
+	},
+  overrides: [
+    {
+      files: [
+        '**/__tests__/*.{j,t}s?(x)',
+        '**/tests/unit/**/*.spec.{j,t}s?(x)'
+      ],
+      env: {
+        jest: true
+      }
+    }
+  ]
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  preset: '@vue/cli-plugin-unit-jest'
+}

--- a/package.json
+++ b/package.json
@@ -1,90 +1,93 @@
 {
-	"name": "participe",
-	"version": "2.0.0",
-	"private": true,
-	"description": "Ferramenta de participação social da Secretaria Municipal de Urbanismo e Licenciamento – SMUL - e São Paulo Urbanismo",
-	"author": {
-		"name": "São Paulo Urbanismo",
-		"email": "desenvolvimento@spurbanismo.sp.gov.br"
-	},
-	"contributors": [
-		{
-			"name": "Thomas Yuba",
-			"email": "yubathom@gmail.com"
-		},
-		{
-			"name": "Davi Hosogiri",
-			"email": "hosogiri.davi@gmail.com"
-		},
-		{
-			"name": "Renan Gomes",
-			"email": "renan.smul@gmail.com"
-		},
-		{
-			"name": "Alex Santana Boccia",
-			"email": "alexboccia@gmail.com"
-		},
-		{
-			"name": "Flávia Lopes Martins Pereira",
-			"email": "flavia.lmpereira@gmail.com"
-		},
-		{
-			"name": "Rogério Lobo",
-			"email": "matusael5004@hotmail.com"
-		}
-	],
-	"license": "(GPL-3.0)",
-	"keywords": [
-		"participe",
-		"participacao",
-		"gestao",
-		"government",
-		"sao-paulo",
-		"prefeitura",
-		"vuejs"
-	],
-	"homepage": "https://participe.gestaourbana.prefeitura.sp.gov.br/",
-	"bugs": "https://github.com/SPURB/participe/issues",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/SPURB/participe.git"
-	},
-	"scripts": {
-		"serve": "vue-cli-service serve",
-		"build": "vue-cli-service build",
-		"lint": "vue-cli-service lint",
-		"build-homolog": "vue-cli-service build --mode staging",
-		"build-local": "vue-cli-service build --mode development",
-		"serve-homolog": "vue-cli-service serve --mode staging",
-		"serve:e2e": "start-server-and-test serve http://localhost:8080 e2e:open",
-		"tests": "start-server-and-test serve http://localhost:8080 e2e",
-		"e2e": "cypress run",
-		"e2e:open": "cypress open"
-	},
-	"dependencies": {
-		"@spurb/fechadura": "1.0.1",
-		"axios": "0.19.0",
-		"cypress": "3.8.0",
-		"es6-promise": "4.2.8",
-		"ol": "5.3.3",
-		"vee-validate": "2.2.15",
-		"vue": "2.6.11",
-		"vue-observe-visibility": "0.4.6",
-		"vue-router": "3.1.3",
-		"vuex": "3.1.2"
-	},
-	"devDependencies": {
-		"@vue/cli-plugin-babel": "3.12.1",
-		"@vue/cli-plugin-eslint": "3.12.1",
-		"@vue/cli-service": "3.12.1",
-		"@vue/eslint-config-standard": "4.0.0",
-		"chai": "4.2.0",
-		"eslint": "5.16.0",
-		"node-sass": "4.13.0",
-		"prerender-spa-plugin": "3.4.0",
-		"sass-loader": "8.0.0",
-		"start-server-and-test": "1.10.6",
-		"vue-cli-plugin-prerender-spa": "1.1.6",
-		"vue-template-compiler": "2.6.11"
-	}
+  "name": "participe",
+  "version": "2.0.0",
+  "private": true,
+  "description": "Ferramenta de participação social da Secretaria Municipal de Urbanismo e Licenciamento – SMUL - e São Paulo Urbanismo",
+  "author": {
+    "name": "São Paulo Urbanismo",
+    "email": "desenvolvimento@spurbanismo.sp.gov.br"
+  },
+  "scripts": {
+    "serve": "vue-cli-service serve",
+    "build": "vue-cli-service build",
+    "e2e": "cypress run",
+    "lint": "vue-cli-service lint",
+    "build-homolog": "vue-cli-service build --mode staging",
+    "build-local": "vue-cli-service build --mode development",
+    "e2e:open": "cypress open",
+    "serve-homolog": "vue-cli-service serve --mode staging",
+    "serve:e2e": "start-server-and-test serve http://localhost:8080 e2e:open",
+    "test:unit": "vue-cli-service test:unit",
+    "tests": "start-server-and-test serve http://localhost:8080 e2e"
+  },
+  "dependencies": {
+    "@spurb/fechadura": "1.0.1",
+    "axios": "0.19.0",
+    "cypress": "3.8.0",
+    "es6-promise": "4.2.8",
+    "ol": "5.3.3",
+    "vee-validate": "2.2.15",
+    "vue": "2.6.11",
+    "vue-observe-visibility": "0.4.6",
+    "vue-router": "3.1.3",
+    "vuex": "3.1.2"
+  },
+  "devDependencies": {
+    "@vue/cli-plugin-babel": "3.12.1",
+    "@vue/cli-plugin-eslint": "3.12.1",
+    "@vue/cli-plugin-unit-jest": "^4.1.2",
+    "@vue/cli-service": "3.12.1",
+    "@vue/eslint-config-standard": "4.0.0",
+    "@vue/test-utils": "1.0.0-beta.29",
+    "chai": "4.2.0",
+    "eslint": "5.16.0",
+    "node-sass": "4.13.0",
+    "prerender-spa-plugin": "3.4.0",
+    "sass-loader": "8.0.0",
+    "start-server-and-test": "1.10.6",
+    "vue-cli-plugin-prerender-spa": "1.1.6",
+    "vue-template-compiler": "2.6.11"
+  },
+  "bugs": "https://github.com/SPURB/participe/issues",
+  "contributors": [
+    {
+      "name": "Thomas Yuba",
+      "email": "yubathom@gmail.com"
+    },
+    {
+      "name": "Davi Hosogiri",
+      "email": "hosogiri.davi@gmail.com"
+    },
+    {
+      "name": "Renan Gomes",
+      "email": "renan.smul@gmail.com"
+    },
+    {
+      "name": "Alex Santana Boccia",
+      "email": "alexboccia@gmail.com"
+    },
+    {
+      "name": "Flávia Lopes Martins Pereira",
+      "email": "flavia.lmpereira@gmail.com"
+    },
+    {
+      "name": "Rogério Lobo",
+      "email": "matusael5004@hotmail.com"
+    }
+  ],
+  "homepage": "https://participe.gestaourbana.prefeitura.sp.gov.br/",
+  "keywords": [
+    "participe",
+    "participacao",
+    "gestao",
+    "government",
+    "sao-paulo",
+    "prefeitura",
+    "vuejs"
+  ],
+  "license": "(GPL-3.0)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/SPURB/participe.git"
+  }
 }

--- a/src/components/Comments.vue
+++ b/src/components/Comments.vue
@@ -61,7 +61,7 @@
 					<circle class="bolinha2" cx="80" cy="14.9" r="3.4"/>
 					<path class="bolinha3" d="M92.9 15a3.4 3.4 0 1 1-3.4-3.5c1.8 0 3.4 1.5 3.4 3.4z"/>
 				</svg>
-				<a @click="checkName" :class="{ enviando: enviandoComment, erro: erro }"></a>
+				<a @click="checkName" class="action__button" :class="{ enviando: enviandoComment, erro: erro }"></a>
 			</div>
 		</form>
 	</div>
@@ -78,8 +78,8 @@ export default {
 			required: true,
 			type: Object
 		}
-	},
-	mixins: [ commentsCommons ],
+  },
+  mixins: [ commentsCommons ],
 	methods: {
 		send () {
 			let app = this

--- a/tests/unit/Comments.spec.js
+++ b/tests/unit/Comments.spec.js
@@ -1,0 +1,38 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils'
+
+// plugins necessários pro teste
+import VeeValidate, { Validator } from 'vee-validate'
+import ptbr from 'vee-validate/dist/locale/pt_BR'
+
+// componente que vai, de fato, ser testado
+import Comments from '@/components/Comments.vue'
+
+describe('Comments.vue', () => {
+  it('Call checkName() method on .action click', () => {
+
+    // tem que osar o createLocalVue() pq esse componente usa plugins, e é necessário linkar o plugin à instancia
+    const localVue = createLocalVue();
+    localVue.use(VeeValidate, { inject: false }) // para não injetar em todos os componentes
+    Validator.localize('pt_br', ptbr)
+
+    // o jest.fn() cria uma função rastreável pelo teste, e vou sobrepor a checkName que tá no mixin, 
+    // pq quero ver se, ao clicar no botão de submit, se ele chama corretamente a checkName
+    const checkName = jest.fn(); 
+
+    const wrapper = shallowMount(Comments, {
+      localVue,
+      propsData: { 
+        attr: {
+          id: 1, 
+          context:'Component test'
+        }
+      },
+      methods: {
+        checkName
+      }
+    })
+
+    wrapper.find("a.action__button").trigger("click");
+    expect(checkName).toBeCalled()
+  })
+})


### PR DESCRIPTION
Ref. #158 
Adicionei o Jest ao projeto usando o vue-cli (caso faça diferença).
Ele criou os arquivos de dependencia automaticamente.

Como Prova de Conceito, eu criei um teste que verifica se o método correto é chamado quando clica no link de enviar comentário no componente `Comments.vue`

Foi adicionado no `package.json` o comando de teste unitário:
```
npm run test:unit
```
Daqui em diante, já dá pra criar os testes unitários pra cada componente.