### PR TITLE
Test/integra com ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Participe
 [![Netlify Status](https://api.netlify.com/api/v1/badges/fb06bdad-d959-414d-b42d-1891b7862c9f/deploy-status)](https://app.netlify.com/sites/participe-gestaourbana/deploys)
+[![Build Status](https://travis-ci.org/SPURB/participe.svg?branch=master)](https://travis-ci.org/SPURB/participe)
 
 Frontend do [https://participe.gestaourbana.prefeitura.sp.gov.br](https://participe.gestaourbana.prefeitura.sp.gov.br), site de participação social da Secretaria Municipal de Urbanismo e Licenciamento – SMUL - e São Paulo Urbanismo.
 
@@ -56,8 +57,7 @@ Toda contribuição é bem vinda. Crie uma [issue](https://github.com/SPURB/part
     <td align="center"><a href="https://github.com/alexboccia"><img src="https://avatars3.githubusercontent.com/u/32138082?s=460&v=4" width="100px;" alt="Alex Boscia"/><br /><sub><b>Alex Boscia</b></sub></a><br /><a href="https://github.com/spurb/participe/commits?author=alexboccia" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/davimh"><img src="https://avatars1.githubusercontent.com/u/32531840?s=460&v=4" width="100px;" alt="Thomas Yuba"/><br /><sub><b>Davi Masayuki</b></sub></a><br /><a href="https://github.com/spurb/participe/commits?author=davimh" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/educkf"><img src="https://avatars2.githubusercontent.com/u/2439707?s=460&v=4" width="100px;" alt="Eduardo Camillo"/><br /><sub><b>Eduardo Camillo</b></sub></a><br /><a href="https://github.com/spurb/participe/commits?author=educkf" title="Code">💻</a></td>
-    <td align="center"><a href="https://github.com/flavinhalopes"><img src="https://avatars1.githubusercontent.com/u/39636035?s=460&v=4
-    " width="100px;" alt="Flávia Lopes"/><br /><sub><b>Flávia Lopes</b></sub></a><br /><a href="https://github.com/spurb/participe/commits?author=flavinhalopes" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/flavinhalopes"><img src="https://avatars1.githubusercontent.com/u/39636035?s=460&v=4" width="100px;" alt="Flávia Lopes"/><br /><sub><b>Flávia Lopes</b></sub></a><br /><a href="https://github.com/spurb/participe/commits?author=flavinhalopes" title="Code">💻</a></td>
  </tr>
  <tr>
     <td align="center"><a href="https://github.com/lordscorp"><img src="https://avatars1.githubusercontent.com/u/40305353?s=460&v=4" width="100px;" alt="Renan Moreira Gomes"/><br /><sub><b>Renan Gomes</b></sub></a><br /><a href="https://github.com/spurb/participe/commits?author=lordscorp" title="Code">💻</a></td>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1615,7 +1615,7 @@
 				},
 				"eslint": {
 					"version": "4.19.1",
-					"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+					"resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
 					"integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
 					"dev": true,
 					"optional": true,
@@ -2361,12 +2361,16 @@
 			}
 		},
 		"@vue/eslint-config-standard": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@vue/eslint-config-standard/-/eslint-config-standard-5.0.1.tgz",
-			"integrity": "sha512-8QHYlaGcO1/0IDe0JpzF6DHsQgzHUCqnrBhsX+Y9NmM81ek5XWrxzKfoMQbNXnvy69D/NzI3+a4incYAR36J0A==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@vue/eslint-config-standard/-/eslint-config-standard-4.0.0.tgz",
+			"integrity": "sha512-bQghq1cw1BuMRHNhr3tRpAJx1tpGy0QtajQX873kLtA9YVuOIoXR7nAWnTN09bBHnSUh2N288vMsqPi2fI4Hzg==",
 			"dev": true,
 			"requires": {
-				"eslint-config-standard": "^14.1.0"
+				"eslint-config-standard": "^12.0.0",
+				"eslint-plugin-import": "^2.14.0",
+				"eslint-plugin-node": "^8.0.0",
+				"eslint-plugin-promise": "^4.0.1",
+				"eslint-plugin-standard": "^4.0.0"
 			}
 		},
 		"@vue/preload-webpack-plugin": {
@@ -2588,7 +2592,7 @@
 		"abbrev": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+			"integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg=",
 			"dev": true
 		},
 		"accepts": {
@@ -2619,7 +2623,7 @@
 		},
 		"acorn-jsx": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
 			"dev": true,
 			"optional": true,
@@ -2629,7 +2633,7 @@
 			"dependencies": {
 				"acorn": {
 					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+					"resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
 					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
 					"dev": true,
 					"optional": true
@@ -2728,7 +2732,7 @@
 		"anymatch": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+			"integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
 			"dev": true,
 			"requires": {
 				"micromatch": "^3.1.4",
@@ -2749,7 +2753,7 @@
 		"aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+			"integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo=",
 			"dev": true
 		},
 		"arch": {
@@ -2760,7 +2764,7 @@
 		"are-we-there-yet": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+			"integrity": "sha1-SzXClE8GKov82mZBB2A1D+nd/CE=",
 			"dev": true,
 			"requires": {
 				"delegates": "^1.0.0",
@@ -2770,7 +2774,7 @@
 		"argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
 			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
@@ -2785,7 +2789,7 @@
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
 			"dev": true
 		},
 		"arr-union": {
@@ -2812,6 +2816,96 @@
 			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
 			"dev": true
 		},
+		"array-includes": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.1.tgz",
+			"integrity": "sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0",
+				"is-string": "^1.0.5"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.17.0",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0.tgz",
+					"integrity": "sha512-yYkE07YF+6SIBmg1MsJ9dlub5L48Ek7X0qz+c/CPCHS9EBXfESorzng4cJQjJW5/pB6vDF41u7F8vUhLVDqIug==",
+					"dev": true,
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.1.5",
+						"is-regex": "^1.0.5",
+						"object-inspect": "^1.7.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.0",
+						"string.prototype.trimleft": "^2.1.1",
+						"string.prototype.trimright": "^2.1.1"
+					}
+				},
+				"es-to-primitive": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+					"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+					"dev": true,
+					"requires": {
+						"is-callable": "^1.1.4",
+						"is-date-object": "^1.0.1",
+						"is-symbol": "^1.0.2"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+					"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+					"dev": true
+				},
+				"is-callable": {
+					"version": "1.1.5",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+					"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+					"dev": true
+				},
+				"is-regex": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+					"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+					"dev": true,
+					"requires": {
+						"has": "^1.0.3"
+					}
+				},
+				"object-inspect": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+					"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+					"dev": true
+				},
+				"string.prototype.trimleft": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+					"integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+					"dev": true,
+					"requires": {
+						"define-properties": "^1.1.3",
+						"function-bind": "^1.1.1"
+					}
+				},
+				"string.prototype.trimright": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+					"integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+					"dev": true,
+					"requires": {
+						"define-properties": "^1.1.3",
+						"function-bind": "^1.1.1"
+					}
+				}
+			}
+		},
 		"array-union": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -2832,6 +2926,95 @@
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
 			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
 			"dev": true
+		},
+		"array.prototype.flat": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
+			"integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0-next.1"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.17.0",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0.tgz",
+					"integrity": "sha512-yYkE07YF+6SIBmg1MsJ9dlub5L48Ek7X0qz+c/CPCHS9EBXfESorzng4cJQjJW5/pB6vDF41u7F8vUhLVDqIug==",
+					"dev": true,
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.1.5",
+						"is-regex": "^1.0.5",
+						"object-inspect": "^1.7.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.0",
+						"string.prototype.trimleft": "^2.1.1",
+						"string.prototype.trimright": "^2.1.1"
+					}
+				},
+				"es-to-primitive": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+					"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+					"dev": true,
+					"requires": {
+						"is-callable": "^1.1.4",
+						"is-date-object": "^1.0.1",
+						"is-symbol": "^1.0.2"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+					"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+					"dev": true
+				},
+				"is-callable": {
+					"version": "1.1.5",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+					"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+					"dev": true
+				},
+				"is-regex": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+					"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+					"dev": true,
+					"requires": {
+						"has": "^1.0.3"
+					}
+				},
+				"object-inspect": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+					"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+					"dev": true
+				},
+				"string.prototype.trimleft": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+					"integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+					"dev": true,
+					"requires": {
+						"define-properties": "^1.1.3",
+						"function-bind": "^1.1.1"
+					}
+				},
+				"string.prototype.trimright": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+					"integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+					"dev": true,
+					"requires": {
+						"define-properties": "^1.1.3",
+						"function-bind": "^1.1.1"
+					}
+				}
+			}
 		},
 		"asn1": {
 			"version": "0.2.4",
@@ -3302,7 +3485,7 @@
 		"base": {
 			"version": "0.11.2",
 			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+			"integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
 			"dev": true,
 			"requires": {
 				"cache-base": "^1.0.1",
@@ -3326,7 +3509,7 @@
 				"is-accessor-descriptor": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -3335,7 +3518,7 @@
 				"is-data-descriptor": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -3344,7 +3527,7 @@
 				"is-descriptor": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
 					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
@@ -3492,7 +3675,7 @@
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -3680,7 +3863,7 @@
 		"buffer-indexof": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
-			"integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
+			"integrity": "sha1-Uvq8xqYG0aADAoAmSO9o9jnaJow=",
 			"dev": true
 		},
 		"buffer-xor": {
@@ -3735,7 +3918,7 @@
 		"cache-base": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+			"integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
 			"dev": true,
 			"requires": {
 				"collection-visit": "^1.0.0",
@@ -4000,7 +4183,7 @@
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+			"integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
 			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
@@ -4320,7 +4503,7 @@
 		"concat-stream": {
 			"version": "1.6.2",
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+			"integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"inherits": "^2.0.3",
@@ -4411,6 +4594,12 @@
 			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
 			"dev": true
 		},
+		"contains-path": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+			"dev": true
+		},
 		"content-disposition": {
 			"version": "0.5.3",
 			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
@@ -4423,7 +4612,7 @@
 		"content-type": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+			"integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js=",
 			"dev": true
 		},
 		"convert-source-map": {
@@ -4450,7 +4639,7 @@
 		"copy-concurrently": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
-			"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+			"integrity": "sha1-kilzmMrjSTf8r9bsgTnBgFHwteA=",
 			"dev": true,
 			"requires": {
 				"aproba": "^1.1.1",
@@ -5317,7 +5506,7 @@
 		"define-property": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+			"integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
 			"dev": true,
 			"requires": {
 				"is-descriptor": "^1.0.2",
@@ -5327,7 +5516,7 @@
 				"is-accessor-descriptor": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -5336,7 +5525,7 @@
 				"is-data-descriptor": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -5345,7 +5534,7 @@
 				"is-descriptor": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
 					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
@@ -5485,7 +5674,7 @@
 		"dns-packet": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
-			"integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+			"integrity": "sha1-EqpCaYEHW+UAuRDu3NC0fdfe2lo=",
 			"dev": true,
 			"requires": {
 				"ip": "^1.1.0",
@@ -5771,7 +5960,7 @@
 		"errno": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+			"integrity": "sha1-RoTXF3mtOa8Xfj8AeZb3xnyFJhg=",
 			"dev": true,
 			"requires": {
 				"prr": "~1.0.1"
@@ -5780,7 +5969,7 @@
 		"error-ex": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+			"integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
 			"dev": true,
 			"requires": {
 				"is-arrayish": "^0.2.1"
@@ -6244,10 +6433,31 @@
 			}
 		},
 		"eslint-config-standard": {
-			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.0.tgz",
-			"integrity": "sha512-EF6XkrrGVbvv8hL/kYa/m6vnvmUT+K82pJJc4JJVMM6+Qgqh0pnwprSxdduDLB9p/7bIxD+YV5O0wfb8lmcPbA==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-12.0.0.tgz",
+			"integrity": "sha512-COUz8FnXhqFitYj4DTqHzidjIL/t4mumGZto5c7DrBpvWoie+Sn3P4sLEzUGeYhRElWuFEf8K1S1EfvD1vixCQ==",
 			"dev": true
+		},
+		"eslint-import-resolver-node": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+			"integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+			"dev": true,
+			"requires": {
+				"debug": "^2.6.9",
+				"resolve": "^1.5.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
+			}
 		},
 		"eslint-loader": {
 			"version": "2.2.1",
@@ -6261,6 +6471,129 @@
 				"object-hash": "^1.1.4",
 				"rimraf": "^2.6.1"
 			}
+		},
+		"eslint-module-utils": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.5.0.tgz",
+			"integrity": "sha512-kCo8pZaNz2dsAW7nCUjuVoI11EBXXpIzfNxmaoLhXoRDOnqXLC4iSGVRdZPhOitfbdEfMEfKOiENaK6wDPZEGw==",
+			"dev": true,
+			"requires": {
+				"debug": "^2.6.9",
+				"pkg-dir": "^2.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"pkg-dir": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+					"dev": true,
+					"requires": {
+						"find-up": "^2.1.0"
+					}
+				}
+			}
+		},
+		"eslint-plugin-es": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.4.1.tgz",
+			"integrity": "sha512-5fa/gR2yR3NxQf+UXkeLeP8FBBl6tSgdrAz1+cF84v1FMM4twGwQoqTnn+QxFLcPOrF4pdKEJKDB/q9GoyJrCA==",
+			"dev": true,
+			"requires": {
+				"eslint-utils": "^1.4.2",
+				"regexpp": "^2.0.1"
+			},
+			"dependencies": {
+				"regexpp": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+					"integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+					"dev": true
+				}
+			}
+		},
+		"eslint-plugin-import": {
+			"version": "2.19.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.19.1.tgz",
+			"integrity": "sha512-x68131aKoCZlCae7rDXKSAQmbT5DQuManyXo2sK6fJJ0aK5CWAkv6A6HJZGgqC8IhjQxYPgo6/IY4Oz8AFsbBw==",
+			"dev": true,
+			"requires": {
+				"array-includes": "^3.0.3",
+				"array.prototype.flat": "^1.2.1",
+				"contains-path": "^0.1.0",
+				"debug": "^2.6.9",
+				"doctrine": "1.5.0",
+				"eslint-import-resolver-node": "^0.3.2",
+				"eslint-module-utils": "^2.4.1",
+				"has": "^1.0.3",
+				"minimatch": "^3.0.4",
+				"object.values": "^1.1.0",
+				"read-pkg-up": "^2.0.0",
+				"resolve": "^1.12.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"doctrine": {
+					"version": "1.5.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"isarray": "^1.0.0"
+					}
+				}
+			}
+		},
+		"eslint-plugin-node": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-8.0.1.tgz",
+			"integrity": "sha512-ZjOjbjEi6jd82rIpFSgagv4CHWzG9xsQAVp1ZPlhRnnYxcTgENUVBvhYmkQ7GvT1QFijUSo69RaiOJKhMu6i8w==",
+			"dev": true,
+			"requires": {
+				"eslint-plugin-es": "^1.3.1",
+				"eslint-utils": "^1.3.1",
+				"ignore": "^5.0.2",
+				"minimatch": "^3.0.4",
+				"resolve": "^1.8.1",
+				"semver": "^5.5.0"
+			},
+			"dependencies": {
+				"ignore": {
+					"version": "5.1.4",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+					"integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+					"dev": true
+				}
+			}
+		},
+		"eslint-plugin-promise": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
+			"integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
+			"dev": true
+		},
+		"eslint-plugin-standard": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.1.tgz",
+			"integrity": "sha512-v/KBnfyaOMPmZc/dmc6ozOdWqekGp7bBGq4jLAecEfPGmfKiWS4sA8sC0LqiV9w5qmXAtXVn4M3p1jSyhY85SQ==",
+			"dev": true
 		},
 		"eslint-plugin-vue": {
 			"version": "4.7.1",
@@ -6335,7 +6668,7 @@
 		"esrecurse": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+			"integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
 			"dev": true,
 			"requires": {
 				"estraverse": "^4.1.0"
@@ -6592,7 +6925,7 @@
 				"is-extendable": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
 					"dev": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
@@ -6833,7 +7166,7 @@
 		"filesize": {
 			"version": "3.6.1",
 			"resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
-			"integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
+			"integrity": "sha1-CQuz7gG2+AGoqL6Z0xcQs0Irsxc=",
 			"dev": true
 		},
 		"fill-range": {
@@ -7620,7 +7953,7 @@
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
 			"dev": true
 		},
 		"functional-red-black-tree": {
@@ -7648,7 +7981,7 @@
 		"gaze": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
-			"integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
+			"integrity": "sha1-xEFzPhO5J6yMD/C0w7Az8ogSkko=",
 			"dev": true,
 			"requires": {
 				"globule": "^1.0.0"
@@ -7786,7 +8119,7 @@
 		"globule": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
-			"integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
+			"integrity": "sha1-Xf+xsZHyLSB5epNptJ6rTpg5aW0=",
 			"dev": true,
 			"requires": {
 				"glob": "~7.1.1",
@@ -7866,7 +8199,7 @@
 		"has": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
 			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1"
@@ -8078,7 +8411,7 @@
 		},
 		"html-webpack-plugin": {
 			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
 			"integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
 			"dev": true,
 			"requires": {
@@ -8295,7 +8628,7 @@
 		"ignore": {
 			"version": "3.3.10",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-			"integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+			"integrity": "sha1-Cpf7h2mG6AgcYxFg+PnziRV/AEM=",
 			"dev": true
 		},
 		"import-cwd": {
@@ -8569,7 +8902,7 @@
 		"invariant": {
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
 			"dev": true,
 			"requires": {
 				"loose-envify": "^1.0.0"
@@ -8660,7 +8993,7 @@
 		"is-callable": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+			"integrity": "sha1-HhrfIZ4e62hNaR+dagX/DTCiTXU=",
 			"dev": true
 		},
 		"is-ci": {
@@ -8720,7 +9053,7 @@
 		"is-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+			"integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
 			"dev": true,
 			"requires": {
 				"is-accessor-descriptor": "^0.1.6",
@@ -8731,7 +9064,7 @@
 				"kind-of": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+					"integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
 					"dev": true
 				}
 			}
@@ -8822,7 +9155,7 @@
 		},
 		"is-obj": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
 			"dev": true
 		},
@@ -8869,7 +9202,7 @@
 		"is-plain-object": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
 			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
@@ -8899,6 +9232,12 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
 			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+		},
+		"is-string": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+			"integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+			"dev": true
 		},
 		"is-svg": {
 			"version": "3.0.0",
@@ -8938,7 +9277,7 @@
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
 			"dev": true
 		},
 		"is-wsl": {
@@ -9898,7 +10237,7 @@
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
 			"dev": true
 		},
 		"json-schema": {
@@ -10167,6 +10506,29 @@
 				}
 			}
 		},
+		"load-json-file": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^2.2.0",
+				"pify": "^2.0.0",
+				"strip-bom": "^3.0.0"
+			},
+			"dependencies": {
+				"parse-json": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+					"dev": true,
+					"requires": {
+						"error-ex": "^1.2.0"
+					}
+				}
+			}
+		},
 		"loader-fs-cache": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/loader-fs-cache/-/loader-fs-cache-1.0.2.tgz",
@@ -10311,7 +10673,7 @@
 		"log-symbols": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+			"integrity": "sha1-V0Dhxdbw39pK2TI7UzIQfva0xAo=",
 			"requires": {
 				"chalk": "^2.0.1"
 			}
@@ -10334,7 +10696,7 @@
 		"loose-envify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
 			"dev": true,
 			"requires": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
@@ -10522,7 +10884,7 @@
 				},
 				"load-json-file": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+					"resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"dev": true,
 					"requires": {
@@ -10688,7 +11050,7 @@
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+			"integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
 			"dev": true
 		},
 		"mini-css-extract-plugin": {
@@ -10720,7 +11082,7 @@
 		"minimalistic-assert": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+			"integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
 			"dev": true
 		},
 		"minimalistic-crypto-utils": {
@@ -10732,7 +11094,7 @@
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -10823,7 +11185,7 @@
 		"multicast-dns": {
 			"version": "6.2.3",
 			"resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
-			"integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
+			"integrity": "sha1-oOx72QVcQoL3kMPIL04o2zsxsik=",
 			"dev": true,
 			"requires": {
 				"dns-packet": "^1.3.1",
@@ -10862,7 +11224,7 @@
 		"nanomatch": {
 			"version": "1.2.13",
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
-			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+			"integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
 			"dev": true,
 			"requires": {
 				"arr-diff": "^4.0.0",
@@ -10904,7 +11266,7 @@
 		"no-case": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
-			"integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+			"integrity": "sha1-YLgTOWvjmz8SiKTB7V0efSi0ZKw=",
 			"dev": true,
 			"requires": {
 				"lower-case": "^1.1.1"
@@ -11176,7 +11538,7 @@
 		"npmlog": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+			"integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
 			"dev": true,
 			"requires": {
 				"are-we-there-yet": "~1.1.2",
@@ -11337,7 +11699,7 @@
 		"obuf": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
-			"integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+			"integrity": "sha1-Cb6jND1BhZ69RGKS0RydTbYZCE4=",
 			"dev": true
 		},
 		"ol": {
@@ -11536,7 +11898,7 @@
 		"osenv": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+			"integrity": "sha1-hc36+uso6Gd/QW4odZK18/SepBA=",
 			"dev": true,
 			"requires": {
 				"os-homedir": "^1.0.0",
@@ -11572,7 +11934,7 @@
 		"p-limit": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+			"integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
 			"dev": true,
 			"requires": {
 				"p-try": "^1.0.0"
@@ -12554,7 +12916,7 @@
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+			"integrity": "sha1-I4Hts2ifelPWUxkAYPz4ItLzaP8=",
 			"dev": true
 		},
 		"process": {
@@ -12676,7 +13038,7 @@
 		"pumpify": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-			"integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+			"integrity": "sha1-NlE74karJ1cLGjdKXOJ4v9dDcM4=",
 			"dev": true,
 			"requires": {
 				"duplexify": "^3.6.0",
@@ -12743,7 +13105,7 @@
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+			"integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
 		},
 		"query-string": {
 			"version": "4.3.4",
@@ -12859,10 +13221,42 @@
 				}
 			}
 		},
+		"read-pkg-up": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+			"dev": true,
+			"requires": {
+				"find-up": "^2.0.0",
+				"read-pkg": "^2.0.0"
+			},
+			"dependencies": {
+				"path-type": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+					"dev": true,
+					"requires": {
+						"pify": "^2.0.0"
+					}
+				},
+				"read-pkg": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "^2.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^2.0.0"
+					}
+				}
+			}
+		},
 		"readable-stream": {
 			"version": "2.3.6",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+			"integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -12917,7 +13311,7 @@
 		"regenerate": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+			"integrity": "sha1-SoVuxLVuQHfFV1icroXnpMiGmhE=",
 			"dev": true
 		},
 		"regenerate-unicode-properties": {
@@ -12947,7 +13341,7 @@
 		"regex-not": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+			"integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^3.0.2",
@@ -13225,7 +13619,7 @@
 		"ret": {
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+			"integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
 			"dev": true
 		},
 		"retry": {
@@ -13322,7 +13716,7 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+			"integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
 		},
 		"safe-regex": {
 			"version": "1.1.0",
@@ -13336,7 +13730,7 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+			"integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
 		},
 		"sane": {
 			"version": "4.1.0",
@@ -13443,7 +13837,7 @@
 				},
 				"load-json-file": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+					"resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"dev": true,
 					"requires": {
@@ -13616,7 +14010,7 @@
 		"sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+			"integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
 			"dev": true
 		},
 		"saxes": {
@@ -13933,7 +14327,7 @@
 		"snapdragon": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+			"integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
 			"dev": true,
 			"requires": {
 				"base": "^0.11.1",
@@ -13978,7 +14372,7 @@
 		"snapdragon-node": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+			"integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
 			"dev": true,
 			"requires": {
 				"define-property": "^1.0.0",
@@ -13998,7 +14392,7 @@
 				"is-accessor-descriptor": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -14007,7 +14401,7 @@
 				"is-data-descriptor": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -14016,7 +14410,7 @@
 				"is-descriptor": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
 					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
@@ -14029,7 +14423,7 @@
 		"snapdragon-util": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+			"integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
 			"dev": true,
 			"requires": {
 				"kind-of": "^3.2.0"
@@ -14055,7 +14449,7 @@
 		"sockjs": {
 			"version": "0.3.19",
 			"resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
-			"integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
+			"integrity": "sha1-2Xa76ACve9IK4IWY1YI5NQiZPA0=",
 			"dev": true,
 			"requires": {
 				"faye-websocket": "^0.10.0",
@@ -14126,7 +14520,7 @@
 		"source-map-resolve": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+			"integrity": "sha1-cuLMNAlVQ+Q7LGKyxMENSpBU8lk=",
 			"dev": true,
 			"requires": {
 				"atob": "^2.1.1",
@@ -14179,7 +14573,7 @@
 		"spdx-expression-parse": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
 			"dev": true,
 			"requires": {
 				"spdx-exceptions": "^2.1.0",
@@ -14276,7 +14670,7 @@
 		"split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^3.0.0"
@@ -14655,7 +15049,7 @@
 		"string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			}
@@ -15074,7 +15468,7 @@
 		},
 		"through": {
 			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
 			"dev": true
 		},
@@ -15164,7 +15558,7 @@
 		"to-regex": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+			"integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
 			"dev": true,
 			"requires": {
 				"define-property": "^2.0.2",
@@ -15238,7 +15632,7 @@
 		"tryer": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
-			"integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
+			"integrity": "sha1-8shUBoALmw90yfdGW4HqrSQSUvg=",
 			"dev": true
 		},
 		"ts-jest": {
@@ -15520,7 +15914,7 @@
 		"uri-js": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
 			"requires": {
 				"punycode": "^2.1.0"
 			}
@@ -15571,7 +15965,7 @@
 		"use": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+			"integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8=",
 			"dev": true
 		},
 		"util": {
@@ -15599,7 +15993,7 @@
 		"util.promisify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
-			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+			"integrity": "sha1-RA9xZaRZyaFtwUXrjnLzVocJcDA=",
 			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
@@ -15842,7 +16236,7 @@
 		"wbuf": {
 			"version": "1.7.3",
 			"resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
-			"integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
+			"integrity": "sha1-wdjRSTFtPqhShIiVy2oL/oh7h98=",
 			"dev": true,
 			"requires": {
 				"minimalistic-assert": "^1.0.0"
@@ -16279,7 +16673,7 @@
 		"websocket-extensions": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-			"integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
+			"integrity": "sha1-XS/yKXcAPsaHpLhwc9+7rBRszyk=",
 			"dev": true
 		},
 		"whatwg-encoding": {
@@ -16311,7 +16705,7 @@
 		"which": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
 			"requires": {
 				"isexe": "^2.0.0"
 			}
@@ -16325,7 +16719,7 @@
 		"wide-align": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+			"integrity": "sha1-rgdOa9wMFKQx6ATmJFScYzsABFc=",
 			"dev": true,
 			"requires": {
 				"string-width": "^1.0.2 || 2"
@@ -16456,7 +16850,7 @@
 		"y18n": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+			"integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms=",
 			"dev": true
 		},
 		"yallist": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "serve-homolog": "vue-cli-service serve --mode staging",
     "serve:e2e": "start-server-and-test serve http://localhost:8080 e2e:open",
     "test:unit": "vue-cli-service test:unit",
-    "tests": "start-server-and-test serve http://localhost:8080 e2e"
+    "test:e2e": "start-server-and-test serve http://localhost:8080 e2e"
   },
   "dependencies": {
     "@spurb/fechadura": "1.0.1",
@@ -37,7 +37,7 @@
     "@vue/cli-plugin-eslint": "3.12.1",
     "@vue/cli-plugin-unit-jest": "^4.1.2",
     "@vue/cli-service": "3.12.1",
-    "@vue/eslint-config-standard": "5.0.1",
+    "@vue/eslint-config-standard": "4.0.0",
     "@vue/test-utils": "1.0.0-beta.29",
     "chai": "4.2.0",
     "eslint": "5.16.0",

--- a/tests/e2e/integration/home.spec.js
+++ b/tests/e2e/integration/home.spec.js
@@ -1,22 +1,7 @@
-// https://docs.cypress.io/api/introduction/api.html
-
 describe('Home', () => {
 	it('Existe h1 com substring "participe"', () => {
-		cy.seedAndVisit()
+		cy.visit('/')
 			.get('h1')
 			.should('contain','participe')
-	})
-
-	it('Número de consultas na DOM é o mesmo dos elementos array da resposta da API (tabela "consultas")', () => {
-		let nConsultas
-		let nConsultasDOM = 0
-
-		cy.seedAndVisit()
-			.then(res => nConsultas = res.response.body.length)
-			.get('section.abertas').children('ul').children('li')
-			.then(itens => nConsultasDOM = nConsultasDOM + itens.length)
-			.get('section.encerradas').children('ul').children('li')
-			.then(itens => nConsultasDOM = nConsultasDOM + itens.length )
-			.should(() => expect(nConsultas === nConsultasDOM).to.equal(true, 'Há mesmo número de itens na API e nas listas da DOM (soma de abertas e encerradas)'))
 	})
 })

--- a/travis.yml
+++ b/travis.yml
@@ -1,0 +1,20 @@
+language: node_js
+node_js:
+ - lts/*
+
+cache:
+ npm: true
+ directories:
+  - node_modules
+  - ~/.cache
+
+branches:
+ only:
+  - master
+
+install:
+ - npm install
+
+script:
+ - npm run test:unit
+ - npm run test:e2e


### PR DESCRIPTION
#162 
Obs: Também reverte `@vue/eslint-config-standard` de `5.0.1` para `4.0.0` pois esta atualização quebrou o linter e o comando `run serve`  